### PR TITLE
fix: bundle explore link path

### DIFF
--- a/src/bundles/explore.js
+++ b/src/bundles/explore.js
@@ -89,6 +89,10 @@ const makeBundle = () => {
     const pathParts = pathBoundaries.map(p => p.path)
     // add the extra path step from the link to the end
     if (link && link.path) {
+      if (pathParts.length) {
+        // DagPb data model format is /Links/0/Hash/Links/0/Hash
+        pathParts.push('Hash')
+      }
       pathParts.push(link.path)
     }
     // add the root cid to the start


### PR DESCRIPTION
After looking at the info in #279  and trying it out, I am a bit clueless if this is a good fix as this goes really outside my expertise. Sharing what I discovered.

Going to https://explore.ipld.io/#/explore/QmWYmE8fzNRYg48E5PaDhMfHqfbPjyQVmUjGQfgAsa4NYq and then opening its first link, it will work (https://explore.ipld.io/#/explore/QmWYmE8fzNRYg48E5PaDhMfHqfbPjyQVmUjGQfgAsa4NYq/Links/0), however opening the following link will fail (https://explore.ipld.io/#/explore/QmWYmE8fzNRYg48E5PaDhMfHqfbPjyQVmUjGQfgAsa4NYq/Links/0/Links/0). Per @rvagg [input](https://github.com/ipfs/ipld-explorer-components/issues/279#issuecomment-696640627), I figured out the url should have the `/Hash` in, and trying it out worked: https://explore.ipld.io/#/explore/QmWYmE8fzNRYg48E5PaDhMfHqfbPjyQVmUjGQfgAsa4NYq/Links/0/Hash/Links/0

So, I discovered how to add the `Hash`, assuming it should always happen when we are on a path with multiple Links? Other solution is to inject the Hash on the table itself (I think by simply changing this https://github.com/ipfs/ipld-explorer-components/blob/master/src/lib/resolve-ipld-path.js#L48 to linkPath). Let me know if any of these solutions and my assumptions are correct

----

Note: The current error is like #284 

![image](https://user-images.githubusercontent.com/7295071/123242968-d7041b00-d4e2-11eb-85fb-e2b6eb0f381d.png)

Closes #279 