### PR TITLE
Add CID row styling to allow scrolling and remove ellipsis

### DIFF
--- a/src/components/object-info/LinksTable.css
+++ b/src/components/object-info/LinksTable.css
@@ -1,3 +1,7 @@
 .LinksTable .ReactVirtualized__Table__Grid {
   background: rgba(255,255,255,0.7)
 }
+
+.LinksTable .ReactVirtualized__Table__rowColumn.no-ellipsis {
+  text-overflow: unset;
+}

--- a/src/components/object-info/LinksTable.js
+++ b/src/components/object-info/LinksTable.js
@@ -11,6 +11,9 @@ class LinksTable extends React.Component {
   render () {
     const { links } = this.props
     const headerClassName = 'mid-gray fw2 tracked silver'
+    const cidRowStyle = {
+      overflow: 'auto'
+    }
     const rowHeight = 29
     const headerHeight = 32
     const tableHeight = Math.max(370, (Math.min(window.innerHeight - 500, links.length * rowHeight + headerHeight)))
@@ -31,7 +34,7 @@ class LinksTable extends React.Component {
             >
               <Column dataKey='index' width={34} className='pv2 silver monospace tr pr1' />
               <Column label='Path' dataKey='path' width={210} flexGrow={1} className='pv2 navy f6-ns' headerClassName={headerClassName} />
-              <Column label='CID' dataKey='target' width={360} className='pv2 mid-gray monospace' headerClassName={headerClassName} />
+              <Column label='CID' dataKey='target' width={360} className='pv2 mid-gray monospace no-ellipsis' headerClassName={headerClassName} style={cidRowStyle} />
             </Table>
           )}
         </AutoSizer>


### PR DESCRIPTION
This PR overrides the default ellipsis truncation for CID rows in virtualized tables. This allows the user to be able to scroll to see the last bytes of a CID in the Explore Table.

Fixes  https://github.com/ipld/explore.ipld.io/issues/71