### PR TITLE
docs: fix community CONTRIBUTING.md links

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,9 @@ import 'ipld-explorer-lib/dist/components/loader/Loader.css'
 
 Feel free to dive in! [Open an issue](https://github.com/ipfs-shipyard/ipld-explorer/issues/new) or submit PRs.
 
-To contribute to IPFS in general, see the [contributing guide](https://github.com/ipfs/community/blob/master/contributing.md).
+To contribute to IPFS in general, see the [contributing guide](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md).
 
-[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/contributing.md)
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)
 
 ## Releasing
 


### PR DESCRIPTION
current contributing.md link returns 404
Related: https://github.com/ipfs/ipfs-companion/pull/1038