### PR TITLE
fix: convert car stream to iterable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "multibase": "4.0.2",
         "multiformats": "^9.6.4",
         "multihashes": "^4.0.3",
-        "react-joyride": "^2.3.0"
+        "react-joyride": "^2.3.0",
+        "stream-to-it": "^0.2.4"
       },
       "devDependencies": {
         "@babel/core": "^7.13.15",
@@ -19348,6 +19349,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
     },
     "node_modules/get-own-enumerable-property-symbols": {
       "version": "3.0.2",
@@ -39053,6 +39059,14 @@
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
+    "node_modules/stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "dependencies": {
+        "get-iterator": "^1.0.2"
+      }
+    },
     "node_modules/strftime": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/strftime/-/strftime-0.10.0.tgz",
@@ -58471,6 +58485,11 @@
         "has-symbols": "^1.0.1"
       }
     },
+    "get-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-iterator/-/get-iterator-1.0.2.tgz",
+      "integrity": "sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg=="
+    },
     "get-own-enumerable-property-symbols": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
@@ -73659,6 +73678,14 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
       "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
+    },
+    "stream-to-it": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.4.tgz",
+      "integrity": "sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==",
+      "requires": {
+        "get-iterator": "^1.0.2"
+      }
     },
     "strftime": {
       "version": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "multibase": "4.0.2",
     "multiformats": "^9.6.4",
     "multihashes": "^4.0.3",
-    "react-joyride": "^2.3.0"
+    "react-joyride": "^2.3.0",
+    "stream-to-it": "^0.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.13.15",

--- a/src/bundles/explore.js
+++ b/src/bundles/explore.js
@@ -118,7 +118,8 @@ const makeBundle = () => {
 
 async function importCar (file, ipfs) {
   const inStream = file.stream()
-  for await (const result of ipfs.dag.import(inStream)) {
+  const toIterable = require('stream-to-it')
+  for await (const result of ipfs.dag.import(toIterable.source(inStream))) {
     return result
   }
 }

--- a/src/components/explore/IpldCarExploreForm.js
+++ b/src/components/explore/IpldCarExploreForm.js
@@ -30,7 +30,7 @@ class IpldCarExploreForm extends React.Component {
       <form data-id='IpldCarExploreForm' className='sans-serif black-80 flex' onSubmit={this.handleOnSubmit} encType='multipart/form-data'>
         <div className='flex-auto'>
           <div className='relative'>
-            <input id='car-file' type='file' className='input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{ borderRadius: '3px 0 0 3px', backgroundColor: 'white', padding: '5px 0px 5px 5px', width: '99%' }} aria-describedby='name-desc' onChange={this.handleOnChange} />
+            <input id='car-file' type='file' accept='.car' className='input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{ borderRadius: '3px 0 0 3px', backgroundColor: 'white', padding: '5px 0px 5px 5px', width: '99%' }} aria-describedby='name-desc' onChange={this.handleOnChange} />
             <small id='car-file-desc' className='o-0 absolute f6 black-60 db mb2'>{t('IpldCarExploreForm.uploadCarFile')}</small>
           </div>
         </div>

--- a/src/components/explore/IpldCarExploreForm.js
+++ b/src/components/explore/IpldCarExploreForm.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
-import StrokeIpld from '../../icons/StrokeIpld'
 
 class IpldCarExploreForm extends React.Component {
   constructor (props) {

--- a/src/components/explore/IpldCarExploreForm.js
+++ b/src/components/explore/IpldCarExploreForm.js
@@ -16,12 +16,12 @@ class IpldCarExploreForm extends React.Component {
 
   handleOnSubmit (evt) {
     evt.preventDefault()
-    this.props.doUploadUserProvidedCar(this.state.file)
   }
 
   handleOnChange () {
     const selectedFile = document.getElementById('car-file').files[0]
     this.setState({ file: selectedFile })
+    this.props.doUploadUserProvidedCar(selectedFile)
   }
 
   render () {
@@ -33,16 +33,6 @@ class IpldCarExploreForm extends React.Component {
             <input id='car-file' type='file' className='input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{ borderRadius: '3px 0 0 3px', backgroundColor: 'white', padding: '5px 0px 5px 5px', width: '99%' }} aria-describedby='name-desc' onChange={this.handleOnChange} />
             <small id='car-file-desc' className='o-0 absolute f6 black-60 db mb2'>{t('IpldCarExploreForm.uploadCarFile')}</small>
           </div>
-        </div>
-        <div className='flex-none'>
-          <button
-            type='submit'
-            className='button-reset dib lh-copy pv1 pl2 pr3 ba f7 fw4 focus-outline white bg-aqua bn'
-            style={{ borderRadius: '0 3px 3px 0' }}
-          >
-            <StrokeIpld style={{ height: 24 }} className='dib fill-current-color v-mid' />
-            <span className='ml2'>{t('IpldExploreForm.explore')}</span>
-          </button>
         </div>
       </form>
     )


### PR DESCRIPTION
# Changes

This is an extension to the previous PR to support CAR import.

+ The in-memory js-ipfs requires the CAR file (stream) to be an 'iterable' object. This means we need to convert the ReadableStream to AsyncIterable.

+ Instead of showing `Explore` button when CAR import is chosen, we instead should just consume the CAR directly and import the dag file as soon as the user uploads the file.


# Related to
https://github.com/ipfs/ipld-explorer-components/pull/313
https://github.com/ipld/explore.ipld.io/pull/82