### PR TITLE
fix: remove unmatched parenthesis

### DIFF
--- a/src/components/cid-info/CidInfo.js
+++ b/src/components/cid-info/CidInfo.js
@@ -17,7 +17,7 @@ function extractInfo (cid) {
     resultArray[chunkIndex].push(item)
     return resultArray
   }, [])
-  const humanReadable = `${cidInfo.multibase.name} - cidv${cidInfo.cid.version} - ${cidInfo.cid.codec} - ${hashFn}~${hashLengthInBits}~${hashValue})`
+  const humanReadable = `${cidInfo.multibase.name} - cidv${cidInfo.cid.version} - ${cidInfo.cid.codec} - ${hashFn}~${hashLengthInBits}~${hashValue}`
   return {
     hashFn,
     hashFnCode,


### PR DESCRIPTION
There is a wild parenthesis on the human readable format of the CID data.