### PR TITLE
fix: url-encoded dag-PB names can be explored

### DIFF
--- a/src/bundles/explore.js
+++ b/src/bundles/explore.js
@@ -103,7 +103,7 @@ const makeBundle = () => {
     }
     // add the root cid to the start
     pathParts.unshift(cid)
-    const path = pathParts.join('/')
+    const path = pathParts.map((part) => encodeURIComponent(part)).join('/')
     const hash = `#/explore/${path}`
     store.doUpdateHash(hash)
   }


### PR DESCRIPTION
fixes https://github.com/ipld/explore.ipld.io/issues/122
