### PR TITLE
CID search fix: empty searches are blocked

### DIFF
--- a/src/components/explore/IpldExploreForm.jsx
+++ b/src/components/explore/IpldExploreForm.jsx
@@ -17,7 +17,7 @@ class IpldExploreForm extends React.Component {
 
   handleOnSubmit (evt) {
     evt.preventDefault()
-    if (!this.state.path.length) {
+    if (this.state.path.trim().length === 0) {
       this.setState((prevState) => ({ ...prevState, showEmptyError: true }))
       return
     }
@@ -26,17 +26,23 @@ class IpldExploreForm extends React.Component {
 
   handleOnChange (evt) {
     const path = evt.target.value
-    if (this.state.showEmptyError && path.length) this.setState((prevState) => ({ ...prevState, showEmptyError: false }))
-    this.setState({ path })
+    let showEmptyError = this.state.showEmptyError
+    if (showEmptyError && path.length > 0) {
+      showEmptyError = false
+    }
+    this.setState({ path, showEmptyError })
   }
 
   render () {
     const { t } = this.props
+    const outline = this.state.showEmptyError ? '2px solid red' : ''
+    const placeholder = this.state.showEmptyError ? 'QmHash can not be empty' : 'QmHash'
+
     return (
       <form data-id='IpldExploreForm' className='sans-serif black-80 flex' onSubmit={this.handleOnSubmit}>
         <div className='flex-auto'>
           <div className='relative'>
-            <input id='ipfs-path' className='input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{ borderRadius: '3px 0 0 3px', outline: (this.state.showEmptyError ? '2px solid red' : '') }} type='text' placeholder={this.state.showEmptyError ? 'QmHash can not be empty' : 'QmHash'} aria-describedby='name-desc' onChange={this.handleOnChange} value={this.state.path} />
+            <input id='ipfs-path' className='input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{ borderRadius: '3px 0 0 3px', outline }} type='text' placeholder={placeholder} aria-describedby='name-desc' onChange={this.handleOnChange} value={this.state.path} />
             <small id='ipfs-path-desc' className='o-0 absolute f6 black-60 db mb2'>Paste in a CID or IPFS path</small>
           </div>
         </div>

--- a/src/components/explore/IpldExploreForm.jsx
+++ b/src/components/explore/IpldExploreForm.jsx
@@ -8,7 +8,8 @@ class IpldExploreForm extends React.Component {
   constructor (props) {
     super(props)
     this.state = {
-      path: ''
+      path: '',
+      showEmptyError: false
     }
     this.handleOnChange = this.handleOnChange.bind(this)
     this.handleOnSubmit = this.handleOnSubmit.bind(this)
@@ -16,11 +17,16 @@ class IpldExploreForm extends React.Component {
 
   handleOnSubmit (evt) {
     evt.preventDefault()
+    if (!this.state.path.length) {
+      this.setState((prevState) => ({ ...prevState, showEmptyError: true }))
+      return
+    }
     this.props.doExploreUserProvidedPath(this.state.path)
   }
 
   handleOnChange (evt) {
     const path = evt.target.value
+    if (this.state.showEmptyError && path.length) this.setState((prevState) => ({ ...prevState, showEmptyError: false }))
     this.setState({ path })
   }
 
@@ -30,14 +36,14 @@ class IpldExploreForm extends React.Component {
       <form data-id='IpldExploreForm' className='sans-serif black-80 flex' onSubmit={this.handleOnSubmit}>
         <div className='flex-auto'>
           <div className='relative'>
-            <input id='ipfs-path' className='input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{ borderRadius: '3px 0 0 3px' }} type='text' placeholder='QmHash' aria-describedby='name-desc' onChange={this.handleOnChange} value={this.state.path} />
+            <input id='ipfs-path' className='input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light focus-outline' style={{ borderRadius: '3px 0 0 3px', outline: (this.state.showEmptyError ? '2px solid red' : '') }} type='text' placeholder={this.state.showEmptyError ? 'QmHash can not be empty' : 'QmHash'} aria-describedby='name-desc' onChange={this.handleOnChange} value={this.state.path} />
             <small id='ipfs-path-desc' className='o-0 absolute f6 black-60 db mb2'>Paste in a CID or IPFS path</small>
           </div>
         </div>
         <div className='flex-none'>
           <button
             type='submit'
-            className='button-reset dib lh-copy pv1 pl2 pr3 ba f7 fw4 focus-outline white bg-aqua bn'
+            className='button-reset dib lh-copy pv1 pl2 pr3 ba f7 fw4 focus-outline white bg-aqua bn cursor-pointer'
             style={{ borderRadius: '0 3px 3px 0' }}
           >
             <StrokeIpld style={{ height: 24 }} className='dib fill-current-color v-mid navy 0-100' />


### PR DESCRIPTION
Now empty searches can not be executed now.

Approach:
- Implemented a if check on the input string
- which updates the state of the search bar component for rendering the error message.
- Additionally changed the outline and placeholder if there is any empty search.