### PR TITLE
fix: use delegated routing over https

### DIFF
--- a/src/lib/init-helia.ts
+++ b/src/lib/init-helia.ts
@@ -25,7 +25,7 @@ export default async function initHelia (kuboGatewayOptions: KuboGatewayOptions)
   if (areRemoteGatewaysEnabled()) {
     // eslint-disable-next-line no-console
     console.log('remote gateways and delegated routing are enabled')
-    routers.push(delegatedHTTPRouting('http://delegated-ipfs.dev'))
+    routers.push(delegatedHTTPRouting('https://delegated-ipfs.dev'))
     routers.push(httpGatewayRouting())
   }
 


### PR DESCRIPTION
I believe Chrome hardcodes `.dev` domains to always use `https` anyway, but other browsers may not do that, and mixed-content failure may occur.