### PR TITLE
fix: webui consumption

### DIFF
--- a/src/components/object-info/links-table.tsx
+++ b/src/components/object-info/links-table.tsx
@@ -46,7 +46,7 @@ interface RowProps {
 
 const Row: React.FC<RowProps> = ({ onLinkClick, startIndex, index, rowHeight, link }) => {
   const key = startIndex + index
-  const backgroundColor = key % 2 === 0 ? '#fff' : 'rgb(251, 251, 251);'
+  const backgroundColor = key % 2 === 0 ? '#fff' : 'rgb(251, 251, 251)'
 
   return (
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions

--- a/src/lib/init-helia.ts
+++ b/src/lib/init-helia.ts
@@ -6,14 +6,15 @@ import { addDagNodeToHelia } from '../lib/helpers.js'
 import { getHashersForCodes } from './hash-importer.js'
 import type { KuboGatewayOptions } from '../types.d.js'
 
+const localStorageKey = 'explore.ipld.gatewayEnabled'
+console.info(
+  `🎛️ Customise whether ipld-explorer-components fetches content from gateways by setting an '${localStorageKey}' value to true/false in localStorage. e.g. localStorage.setItem('${localStorageKey}', false) -- NOTE: defaults to true`
+)
+
 /**
  * Whether to enable remote gateways for fetching content. We default to true if the setting is not present.
  */
 function areRemoteGatewaysEnabled (): boolean {
-  const localStorageKey = 'explore.ipld.gatewayEnabled'
-  console.info(
-    `🎛️ Customise whether ipld-explorer-components fetches content from gateways by setting an '${localStorageKey}' value to true/false in localStorage. e.g. localStorage.setItem('explore.ipld.gatewayEnabled', false) -- NOTE: defaults to true`
-  )
   const gatewayEnabledSetting = localStorage.getItem(localStorageKey)
 
   return gatewayEnabledSetting != null ? JSON.parse(gatewayEnabledSetting) : true

--- a/src/providers/explore.tsx
+++ b/src/providers/explore.tsx
@@ -153,7 +153,7 @@ export const ExploreProvider = ({ children, state, explorePathPrefix = '#/explor
 
   const setExplorePath = (path: string | null): void => {
     const newPath = processPath(path, explorePathPrefix)
-    if (newPath != null && !window.location.href.includes(newPath)) {
+    if (newPath != null && !window.location.href.includes(encodeURI(newPath))) {
       throw new Error('setExplorePath should only be used to update the state, not the URL. If you are using a routing library that doesn\'t allow you to listen to hashchange events, ensure the URL is updated prior to calling setExplorePath.')
     }
     setExploreState((exploreState) => ({

--- a/src/providers/helia.tsx
+++ b/src/providers/helia.tsx
@@ -1,5 +1,5 @@
 import { type Helia } from '@helia/interface'
-import React, { createContext, useContext, useEffect, useState, useCallback } from 'react'
+import React, { createContext, useContext, useState, useCallback } from 'react'
 import packageJson from '../../package.json'
 import initHelia from '../lib/init-helia.js'
 import type { KuboGatewayOptions } from '../types.js'

--- a/src/providers/helia.tsx
+++ b/src/providers/helia.tsx
@@ -68,11 +68,6 @@ export const HeliaProvider = ({ children }: React.ComponentProps<any>): any => {
     }
   }, [kuboGatewayOptions, setHelia])
 
-  useEffect(() => {
-    void doInitHelia()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   return (
     <HeliaContext.Provider value={{ helia, error, kuboGatewayOptions, selectHeliaReady, selectHeliaIdentity, doInitHelia, setKuboGatewayOptions: setKuboGatewayOptionsPublic }}>
       {children}

--- a/src/providers/helia.tsx
+++ b/src/providers/helia.tsx
@@ -29,7 +29,8 @@ const getDefaultKuboGatewayOptions = (): KuboGatewayOptions => {
   const localStorageKuboGatewayOptions = localStorage.getItem('kuboGateway')
   if (localStorageKuboGatewayOptions != null) {
     try {
-      return JSON.parse(localStorageKuboGatewayOptions) as KuboGatewayOptions
+      const kuboGatewaySettings = JSON.parse(localStorageKuboGatewayOptions) as KuboGatewayOptions
+      return { ...defaultKuboGatewayOptions, ...kuboGatewaySettings }
     } catch (e) {
       console.error('getDefaultKuboGatewayOptions error', e)
     }


### PR DESCRIPTION
- **fix: setExplorePath doesnt throw for encoded paths**
- **fix: kuboGateway defaults are handled gracefully**
- **chore: move localStorage info log**
- **fix: do not init helia on mount**


related: https://github.com/ipfs/ipfs-webui/pull/2283