### PR TITLE
fix: links without paths can be navigated

### DIFF
--- a/src/components/object-info/links-table.tsx
+++ b/src/components/object-info/links-table.tsx
@@ -54,7 +54,7 @@ const Row: React.FC<RowProps> = ({ onLinkClick, startIndex, index, rowHeight, li
       key={key}
       className={`pv2 pointer items-center f7 ${styles.rowGrid} bb b--near-white`}
       style={{ position: 'absolute', top: key * rowHeight, width: '100%', backgroundColor }}
-      onClick={() => { onLinkClick(link as any) }}
+      onClick={() => { onLinkClick(link) }}
     >
       <div className={`mid-gray tr pr1 f7 ${styles.gridCellRow} monospace}`}>
         {key}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -19,7 +19,7 @@ export function isFalsy <T> (str: T | null | string | undefined): str is null {
   return false
 }
 
-export function isTruthy <T> (str: T | null | string | undefined): boolean {
+export function isTruthy <T> (str: T | null | string | undefined): str is string {
   return !isFalsy(str)
 }
 

--- a/src/lib/normalise-dag-node.ts
+++ b/src/lib/normalise-dag-node.ts
@@ -93,7 +93,7 @@ export function normaliseDagPb (node: PBNode, cid: string, type: CodecType): Nor
  */
 export function normaliseDagPbLinks (links: PBLink[], sourceCid: string): NormalizedDagLink[] {
   return links.map((link, index) => ({
-    path: link.Name ?? `Links/${index}`,
+    path: isTruthy(link.Name) ? link.Name : `Links/${index}`,
     source: sourceCid,
     target: toCidStrOrNull(link.Hash) ?? '',
     size: BigInt(link.Tsize ?? 0),

--- a/src/lib/resolve-ipld-path.ts
+++ b/src/lib/resolve-ipld-path.ts
@@ -97,7 +97,6 @@ export async function ipldGetNodeAndRemainder (helia: Helia, sourceCid: CID | st
   const encodedValue = await getRawBlock(helia, cidInstance)
   const value = codecWrapper.decode(encodedValue)
 
-  // @ts-expect-error - limiting code changes, ignore this error
   const codecWrapperResolveResult = await codecWrapper.resolve(isTruthy(path) ? path : '/', encodedValue)
   // TODO: there was a type error previously uncaught
   const resolveValue: any = {}


### PR DESCRIPTION
- **chore: remove unnecessary any cast**
- **chore: fix return type on isTruthy**
- **fix: links without paths can be navigated**

Fixes #461

See description of bug at https://github.com/ipfs/ipld-explorer-components/issues/461#issuecomment-2491610750
