### PR TITLE
docs: update devPage file reference to .tsx extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There are `peerDependencies` so that the consuming app can pick the versions of 
 
 ### Use it in your project
 
-You can see an example of how to use these components in the [devPage.jsx](./dev/devPage.jsx) file.
+You can see an example of how to use these components in the [devPage.tsx](./dev/devPage.tsx) file.
 
 ```jsx
 // index.tsx


### PR DESCRIPTION
# Fix incorrect file extension in README

This PR fixes a documentation error in the README where it referenced `devPage.jsx` instead of the correct file `devPage.tsx`.

## Changes
- Updated the file reference from `./dev/devPage.jsx` to `./dev/devPage.tsx` to match the actual file in the repository

## Testing
Documentation-only change, verified that the correct file exists in the repository.