### PR TITLE
chore: add css custom properties for explore page component

### DIFF
--- a/src/components/ExplorePage.tsx
+++ b/src/components/ExplorePage.tsx
@@ -13,6 +13,7 @@ import IpldGraph from './graph/IpldGraphCytoscape.js'
 import GraphCrumb from './graph-crumb/GraphCrumb.js'
 import ComponentLoader from './loader/component-loader.js'
 import { ObjectInfo } from './object-info/ObjectInfo.js'
+import '../index.css'
 
 export const ExplorePage = ({
   runTour = false,
@@ -70,7 +71,7 @@ export const ExplorePage = ({
               ? (
                 <ObjectInfo
                   className='joyride-explorer-node'
-                  style={{ background: '#FBFBFB' }}
+                  style={{ background: 'var(--element-bg, #fbfbfb)' }}
                   cid={targetNode.cid}
                   localPath={localPath}
                   size={targetNode.size}
@@ -95,7 +96,7 @@ export const ExplorePage = ({
               ? (
                 <CidInfo
                   className='joyride-explorer-cid'
-                  style={{ background: '#FBFBFB', overflow: 'hidden' }}
+                  style={{ background: 'var(--element-bg, #fbfbfb)', overflow: 'hidden' }}
                   cid={targetNode.cid}
                 />
                 )

--- a/src/components/about/AboutIpld.tsx
+++ b/src/components/about/AboutIpld.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import Box from '../box/Box.js'
 import ipldLogoSrc from './ipld.svg'
+import '../../index.css'
 
 export const AboutIpld: React.FC = () => {
   const { t } = useTranslation('explore')
 
   return (
-    <Box className='tl dib pa4 avenir measure-wide-l lh-copy dark-gray ba-l b--black-10'>
+    <Box className='tl dib pa4 avenir measure-wide-l lh-copy ba-l' style={{ color: 'var(--text)', borderColor: 'var(--border-color)', border: '1px solid var(--border-color)' }}>
       <div className='tc'>
         <a className='link' href='https://ipld.io'>
           <img src={ipldLogoSrc} alt='IPLD' style={{ height: 60 }} />

--- a/src/components/box/Box.tsx
+++ b/src/components/box/Box.tsx
@@ -12,7 +12,7 @@ export const Box: React.FC<PropsWithChildren<BoxProps>> = ({
   children
 }) => {
   return (
-    <div className={className} style={{ background: '#fbfbfb', ...style }}>
+    <div className={className} style={{ background: 'var(--element-bg, #fbfbfb)', ...style }}>
       <ErrorBoundary>
         {children}
       </ErrorBoundary>

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,16 @@
+/* dark theme styles for the explore page */
+:root {
+  --element-bg: #fbfbfb;
+  --text: #111111;
+  --border-color: rgba(0, 0, 0, 0.1);
+}
+
+[data-theme="dark"] {
+  --background: #181a1b;
+  --text: #e8e6e3;
+  --element-bg: #1a1c1e;
+  --navy-dark: #0b3a53;
+  --navy-text-color: rgb(202, 198, 191);
+  --snow-muted: rgb(28, 30, 31);
+  --border-color: rgba(140, 130, 115, 0.5);
+}


### PR DESCRIPTION
This issue [#1702](https://github.com/ipfs/ipfs-webui/issues/1702) needs dark mode implemented on ipfs-webui, and this PR already addressed part of it.

Since the Explore page on ipfs-webui relies on components from this library, the component in question is expected to include themed-focus styles.
